### PR TITLE
Open link in new tab

### DIFF
--- a/lib/browser_tab.dart
+++ b/lib/browser_tab.dart
@@ -275,6 +275,14 @@ class BrowserTabState extends State<BrowserTab> {
     }
   }
 
+  onNewTabRelativeLink({String initialLocation, bool menuPage }){
+      var location = Uri.tryParse(initialLocation);
+      if (!location.hasScheme) {
+        location = uri.resolve(initialLocation);
+      }
+      onNewTab(initialLocation: location.toString(), menuPage: menuPage);
+  }
+
   onLink(String link) {
     var location = Uri.tryParse(link);
     if (!location.hasScheme) {
@@ -371,6 +379,7 @@ class BrowserTabState extends State<BrowserTab> {
                   contentData: contentData,
                   onLink: onLink,
                   onSearch: onSearch,
+                  onNewTab: onNewTabRelativeLink,
                 ))));
 
     var actions;
@@ -398,7 +407,7 @@ class BrowserTabState extends State<BrowserTab> {
                               fontWeight: FontWeight.bold,
                               fontFamily: "DejaVu Sans Mono",
                               fontSize: 13))))),
-          onPressed: onNewTab,
+          onPressed: () => onNewTab(menuPage: true),
         ),
         IconButton(
             disabledColor: Colors.black12,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -137,11 +137,18 @@ class AppState extends State<App> with AutomaticKeepAliveClientMixin {
     });
   }
 
-  onNewTab({initialLocation}) {
+  onNewTab({String initialLocation, bool menuPage}) {
     if (initialLocation == null) {
       initialLocation = settings["homepage"];
     }
-    if (tabIndex == 0) {
+    if (menuPage ?? false) {
+      //defaults to false if null
+      setState(() {
+        previousTabIndex = tabIndex;
+        tabIndex = 0;
+        print(tabs);
+      });
+    } else { //else when menuPage not set and want to open normal tab
       setState(() {
         var key = GlobalObjectKey(DateTime.now().millisecondsSinceEpoch);
         tabs.add({
@@ -150,11 +157,6 @@ class AppState extends State<App> with AutomaticKeepAliveClientMixin {
               key: key)
         });
         tabIndex = tabs.length;
-      });
-    } else {
-      setState(() {
-        previousTabIndex = tabIndex;
-        tabIndex = 0;
       });
     }
   }


### PR DESCRIPTION
1. Added a Bottom Sheet widget based on @contrapunctus-1's suggestion (a good suggestion imo) to have these options at the bottom.
2. Added a function that makes relative URLs absolute based on the current URL just like onLink.
3. changed onNewTab to make going back to the tabs list an explicit parameter since the current tab index approach wouldn't allow onNewTab to be called from within a tab.
Issue #32 