### PR TITLE
IDN support

### DIFF
--- a/lib/directory/bookmarks.dart
+++ b/lib/directory/bookmarks.dart
@@ -28,8 +28,8 @@ class Bookmarks extends StatelessWidget {
       children = bookmarks.map((bookmarkLocation) {
         var bookmarkUri = Uri.tryParse(bookmarkLocation);
         return GemItem(
-          bookmarkUri.host,
-          title: Text(bookmarkUri.path == "" ? "/" : bookmarkUri.path),
+          Uri.decodeFull(bookmarkUri.host),
+          title: Text(bookmarkUri.path == "" ? "/" : Uri.decodeFull(bookmarkUri.path)),
           showBookmarked: false,
           showDelete: true,
           onSelect: () => onNewTab(initialLocation: bookmarkLocation),

--- a/lib/directory/history.dart
+++ b/lib/directory/history.dart
@@ -31,8 +31,8 @@ class History extends StatelessWidget {
 
         var bookmarked = appKey.currentState.bookmarks.contains(recentLocation);
         return GemItem(
-          recentUri.host,
-          title: Text(recentUri.path == "" ? "/" : recentUri.path),
+          Uri.decodeFull(recentUri.host),
+          title: Text(recentUri.path == "" ? "/" : Uri.decodeFull(recentUri.path)),
           bookmarked: bookmarked,
           showBookmarked: true,
           showDelete: false,

--- a/lib/directory/tabs.dart
+++ b/lib/directory/tabs.dart
@@ -64,7 +64,7 @@ class Tabs extends StatelessWidget {
                   }
                   if (uriString != null && tabState.contentData != null) {
                     var tab = GemItem(
-                      host,
+                      Uri.decodeFull(host),
                       title: ExtendedText(
                         tabState.contentData.content.substring(0,
                             math.min(tabState.contentData.content.length, 500)),

--- a/lib/shared.dart
+++ b/lib/shared.dart
@@ -49,6 +49,7 @@ String toSchemelessString(Uri uri) {
       uriString = uri.toString();
     }
   }
+  uriString =  Uri.decodeFull(uriString);
   return uriString;
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -240,6 +240,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.4"
+  punycode:
+    dependency: "direct main"
+    description:
+      name: punycode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
   qr:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   asn1lib: ^0.6.5
   x509: ^0.1.2+1
   crypto: ^2.1.5
+  punycode: ^0.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
I implemented punycoding when communicating with the server and properly displaying IRIs inside the app. Depending on the stand the spec eventually takes on IRI vs URI it might be more convenient to use an IRI class instead of dart's built in URI with the decodeFull calls.

Should I run `flutter format .` in a new commit or should I leave the formatting as is?
#34 