### PR TITLE
Implement a popup menu and view source

### DIFF
--- a/lib/browser_tab.dart
+++ b/lib/browser_tab.dart
@@ -354,22 +354,26 @@ class BrowserTabState extends State<BrowserTab> {
           ));
     }
 
+    var content = Content(
+      currentUri: uri,
+      contentData: contentData,
+      viewSource: viewingSource &&
+          (contentData?.mode == "content"), //view source if valid gemtext
+      onLocation: onLocation,
+      onSearch: onSearch,
+      onNewTab: onNewTab,
+    );
     var contentWidget = GestureDetector(
         onTapDown: (_) {
           _focusNode.unfocus();
         },
         child: SingleChildScrollView(
-            key: ObjectKey(contentData),
+            key: ObjectKey(content),
             controller: _scrollController,
             child: Padding(
-                padding: EdgeInsets.fromLTRB(20, 20, 17, 20),
-                child: Content(
-                  currentUri: uri,
-                  contentData: contentData,
-                  onLocation: onLocation,
-                  onSearch: onSearch,
-                  onNewTab: onNewTab,
-                ))));
+              padding: EdgeInsets.fromLTRB(20, 20, 17, 20),
+              child: content,
+            )));
 
     var actions;
     if (_showActions) {

--- a/lib/browser_tab.dart
+++ b/lib/browser_tab.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:deedum/address_bar.dart';
 import 'package:deedum/content.dart';
 import 'package:deedum/main.dart';
+import 'package:deedum/browser_tab/menu.dart';
 import 'package:deedum/net.dart';
 import 'package:deedum/shared.dart';
 import 'package:flutter/material.dart';
@@ -57,8 +58,8 @@ class BrowserTabState extends State<BrowserTab> {
 
   List _redirects = [];
   List _logs = [];
-  bool showLogs = false;
   bool _showActions = true;
+  bool viewingSource = false;
 
   BrowserTabState(this.initialLocation, this.onNewTab, this.addRecent);
 
@@ -171,7 +172,7 @@ class BrowserTabState extends State<BrowserTab> {
     });
   }
 
-  Future<void> _showLogs() async {
+  Future<void> showLogs() async {
     return showDialog<void>(
       context: context,
       barrierDismissible: true,
@@ -225,6 +226,10 @@ class BrowserTabState extends State<BrowserTab> {
       },
     );
   }
+
+  void toggleSourceView() => setState(() {
+        viewingSource = !viewingSource;
+      });
 
   void _handleBytes(Uri location, Uint8List newBytes, int requestID) async {
     if (newBytes == null) {
@@ -370,11 +375,6 @@ class BrowserTabState extends State<BrowserTab> {
     if (_showActions) {
       actions = [
         IconButton(
-          icon: Icon(Icons.code),
-          onPressed: () => _showLogs(),
-          color: Colors.black,
-        ),
-        IconButton(
           icon: SizedBox(
               width: 23,
               height: 23,
@@ -399,7 +399,8 @@ class BrowserTabState extends State<BrowserTab> {
             icon: Icon(Icons.chevron_right),
             onPressed: (_historyIndex != (_history.length - 1))
                 ? _handleForward
-                : null)
+                : null),
+        TabMenuWidget(this),
       ];
     }
 

--- a/lib/browser_tab/menu.dart
+++ b/lib/browser_tab/menu.dart
@@ -1,0 +1,40 @@
+import 'package:deedum/browser_tab.dart';
+
+import 'package:flutter/material.dart';
+
+enum _MenuSelection { logs, source }
+
+Widget TabMenuWidget(BrowserTabState tab) {
+  return PopupMenuButton<_MenuSelection>(
+    itemBuilder: (BuildContext context) => [
+      PopupMenuItem(
+          child: ListTile(
+              leading: Icon(Icons.code, color: Colors.black),
+              title: Text("Logs")),
+          value: _MenuSelection.logs),
+      CheckedPopupMenuItem(
+        checked: tab.viewingSource,
+        value: _MenuSelection.source,
+        child: Text("Source"),
+      ),
+    ],
+    onSelected: (result) {
+      switch (result) {
+        case _MenuSelection.logs:
+          {
+            tab.showLogs();
+          }
+          break;
+        case _MenuSelection.source:
+          {
+            tab.toggleSourceView();
+          }
+          break;
+        default:
+          {
+            print("unexpected");
+          }
+      }
+    },
+  );
+}

--- a/lib/content.dart
+++ b/lib/content.dart
@@ -14,10 +14,11 @@ final baseFontSize = 14.0;
 
 class Content extends StatefulWidget {
 
-  Content({this.currentUri, this.contentData, this.onLocation, this.onSearch, this.onNewTab});
+  Content({this.currentUri, this.contentData, this.viewSource, this.onLocation, this.onSearch, this.onNewTab});
 
   final Uri currentUri;
   final ContentData contentData;
+  final bool viewSource;
   final Function onLocation;
   final Function onSearch;
   final Function onNewTab;
@@ -26,6 +27,7 @@ class Content extends StatefulWidget {
   _ContentState createState() => _ContentState(
         currentUri: currentUri,
         contentData: contentData,
+        viewSource: viewSource,
         onLocation: onLocation,
         onSearch: onSearch,
         onNewTab: onNewTab,
@@ -33,10 +35,11 @@ class Content extends StatefulWidget {
 }
 
 class _ContentState extends State<Content> {
-  _ContentState({this.currentUri, this.contentData, this.onLocation, this.onSearch, this.onNewTab});
+  _ContentState({this.currentUri, this.contentData, this.viewSource, this.onLocation, this.onSearch, this.onNewTab});
 
   final Uri currentUri;
   final ContentData contentData;
+  final bool viewSource;
   final Function onLocation;
   final Function onSearch;
   final Function onNewTab;
@@ -61,8 +64,13 @@ class _ContentState extends State<Content> {
   @override
   Widget build(BuildContext context) {
     Widget widget;
+
+
     if (contentData == null) {
       widget = Text("");
+    } else if (contentData.mode == "plain" || viewSource) {
+      var groups = analyze(contentData.content, alwaysPre: true);
+      widget = PreText(contentData.content, groups[0]["maxLine"]);
     } else if (contentData.mode == "content") {
       var groups = analyze(contentData.content);
       widget = groupsToWidget(groups);
@@ -93,9 +101,6 @@ class _ContentState extends State<Content> {
           (BuildContext context, Object exception, StackTrace stackTrace) {
         return ExtendedText("broken image ¯\\_(ツ)_/¯");
       });
-    } else if (contentData.mode == "plain") {
-      var groups = analyze(contentData.content, alwaysPre: true);
-      widget = PreText(contentData.content, groups[0]["maxLine"]);
     } else if (contentData.mode == "opening") {
       widget = ExtendedText(contentData.content);
     } else {


### PR DESCRIPTION
As discussed in #27.
I basically made a view-source page the equivalent of a plaintext page. The scaling is a little awkward, so I'm not sure if it would be better to split each line up into its own `PreText` widget? If the current implementation (everything in one PreText widget) is better, I think how much PreText zooms out could be adjusted?

Two pages with huge differences when viewing source (plaintext):
<gemini://gemini.circumlunar.space/docs/gemtext.gmi> - very zoomed in
<gemini://gemini.circumlunar.space/docs/> - very zoomed out

I'm not sure if that rendering difference is only on my phone?